### PR TITLE
Add docker build workflow

### DIFF
--- a/.github/workflows/build_docker.yml
+++ b/.github/workflows/build_docker.yml
@@ -1,0 +1,64 @@
+name: Build and Publish GitHub Container Docker Image
+on:
+  release:
+    types: [published, edited]
+  push:
+    branches:
+      - main
+  workflow_dispatch:
+
+jobs:
+  build_and_publish_docker_image:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Debug Variables
+        run: |
+            echo "github.event_name: ${{ github.event_name }}"
+            echo "github.ref_name: ${{ github.ref_name }}"
+            echo "github.event.repository.default_branch: ${{ github.event.repository.default_branch }}"
+            echo "github.event.release.target_commitish: ${{ github.event.release.target_commitish }}"
+            echo "github.event.release.prerelease: ${{ github.event.release.prerelease }}"
+            echo "github.event.release.draft: ${{ github.event.release.draft }}"
+      - name: Checkout
+        uses: actions/checkout@v4.2.2
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+      - name: Update Version in const.py
+        if: ${{ github.event_name == 'release' && github.event.repository.default_branch == github.event.release.target_commitish && github.event.release.prerelease == false && github.event.release.draft == false }}
+        run: |
+          sed -i 's/VERSION \= \".*\"/VERSION \= \"${{ github.ref_name }}\"/' ./const.py
+      - name: Commit & Push Version Changes
+        if: ${{ github.event_name == 'release' && github.event.repository.default_branch == github.event.release.target_commitish && github.event.release.prerelease == false && github.event.release.draft == false }}
+        uses: actions-js/push@master
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          branch: ${{ github.event.repository.default_branch }}
+          message: "Updating to version ${{ github.ref_name }}"
+      - name: Extract Docker metadata
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: ghcr.io/${{ github.repository }}
+          flavor: |
+            latest=auto
+          tags: |
+            type=edge,branch=main
+            type=edge,branch=master
+            type=semver,pattern={{version}}
+      - name: Login to GitHub Container Registry
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+      - name: Build and Push Docker Container
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          file: ./Dockerfile
+          push: true
+          platforms: linux/amd64,linux/arm64,linux/arm/v7
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Introduced automated workflow to build and publish Docker images to the GitHub Container Registry on new releases, main branch updates, and manual triggers. This ensures up-to-date Docker images are available for multiple platforms.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->